### PR TITLE
clarify decryption

### DIFF
--- a/pcw_updatedecrypt/README.md
+++ b/pcw_updatedecrypt/README.md
@@ -39,6 +39,9 @@ char secret_key[] = {
    0x85, 0x0c };
    
 [...]
+   unsigned int i = 1;
+   int counter = 0;
+   char key;
    do {
       counter++;
       counter &= 0x0F;


### PR DESCRIPTION
The current README presents an algorithm that uses some uninitialized
variables, which is confusing to the reader.

pull a few more lines out of pcw_deupd.c to flesh out the algorithm in
the README.